### PR TITLE
chore: add full app dev shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ brew upgrade --cask fanguard
 # Install dependencies
 pnpm install
 
-# Run full app (frontend + Rust backend)
-pnpm tauri dev
+# Run full app (builds helper binary + starts frontend + Rust backend)
+pnpm dev:app
 
-# Run with fan control (requires root)
-sudo pnpm tauri dev
+# Equivalent lower-level Tauri command
+pnpm tauri dev
 
 # Frontend unit tests
 pnpm test

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
+		"dev:app": "tauri dev",
 		"dev:prepare-helper": "\"$HOME/.cargo/bin/cargo\" build --manifest-path src-tauri/Cargo.toml --features helper-binary --bin fanguard-helper",
 		"build": "vite build",
 		"build:app-store": "VITE_FANGUARD_DISTRIBUTION=app-store vite build",


### PR DESCRIPTION
## What Change

- Added `pnpm dev:app` as a friendly shortcut for `tauri dev`.
- Updated README development docs to recommend `pnpm dev:app` for full local app testing.
- Removed the quick-start suggestion to run the whole dev app with `sudo`; helper installation should stay behind the explicit privileged-helper flow.

## Why Change

- Local testing needed a single obvious command for the full app path.
- `tauri dev` already runs `dev:prepare-helper` through `beforeDevCommand`, so the alias gives a clearer command without duplicating helper/build logic.
- Avoiding `sudo pnpm tauri dev` keeps normal development safer and closer to the intended helper architecture.

## Impact

- **Affected areas:** package scripts and README development instructions.
- **Breaking changes:** No.
- **Dependencies:** No new dependencies.
- **Testing:** Verified `package.json` resolves `dev:app` to `tauri dev`; verified `pnpm exec tauri --version`; verified `pnpm run dev:prepare-helper` builds `fanguard-helper` successfully.
